### PR TITLE
[FIX] '' and '/' to respond 200 when queried

### DIFF
--- a/app/back/server/src/lib/components/endpoints_routes.py
+++ b/app/back/server/src/lib/components/endpoints_routes.py
@@ -63,10 +63,14 @@ class Endpoints:
         """
         # Bonus routes
         self.runtime_data_initialised.paths_initialised.add_path(
-            "", self.bonus.get_welcome, ["GET", "POST", "PUT", "PATCH"]
+            "", self.bonus.get_welcome, [
+                "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"
+            ]
         )
         self.runtime_data_initialised.paths_initialised.add_path(
-            "/", self.bonus.get_welcome, ["GET", "POST", "PUT", "PATCH"]
+            "/", self.bonus.get_welcome, [
+                "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"
+            ]
         )
         self.runtime_data_initialised.paths_initialised.add_path(
             "/api/v1/", self.bonus.get_welcome, "GET"


### PR DESCRIPTION
This fix is in order to allow the status bot to successfully get a 200 when the site is up by querying the / of the website.
The reason is because I don't know the method used by the bot and this endpoint is literally there to act as a `Hello world!` endpoint.